### PR TITLE
Introduces method to write directory to disk

### DIFF
--- a/pkg/files/files_util.go
+++ b/pkg/files/files_util.go
@@ -22,7 +22,6 @@ package files
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -98,7 +97,7 @@ func WriteToDisk(directory Directory, path string, overwrite bool) (e error) {
 	}
 
 	if info != nil && !info.IsDir() {
-		return errors.New(fmt.Sprintf("provided path pointed to file %s", path))
+		return fmt.Errorf("provided path pointed to file %s", path)
 	}
 
 	if directory.Parent() != nil { // If the directory is not a root directory, we want to create the directory
@@ -125,7 +124,7 @@ func writeFileToDisk(file File, directoryPath string, overwrite bool) (e error) 
 
 	if info != nil { // Checking if the path currently exists
 		if info.IsDir() { // Checking if the path is a directory
-			return errors.New(fmt.Sprintf("provided path pointed to directory %s", path))
+			return fmt.Errorf("provided path pointed to directory %s", path)
 		}
 
 		if !overwrite { // Checking if the file should be overwritten given it exists
@@ -163,7 +162,7 @@ func writeDirectoryToDisk(directory Directory, directoryPath string, overwrite b
 	}
 
 	if info != nil && !info.IsDir() {
-		return errors.New(fmt.Sprintf("provided path pointed to file %s", directoryPath))
+		return fmt.Errorf("provided path pointed to file %s", directoryPath)
 	}
 
 	for _, dir := range directory.Directories() {

--- a/pkg/files/files_util.go
+++ b/pkg/files/files_util.go
@@ -22,6 +22,8 @@ package files
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -79,4 +81,102 @@ func readFileInto(directory Directory, path string) (e error) {
 	}
 
 	return directory.NewFile(paths.Of(path).Drop()).Write(bytes.NewBuffer(content))
+}
+
+// WriteToDisk writes a directory to the given path
+// Overwriting or skipping an existing file based on the bool
+func WriteToDisk(directory Directory, path string, overwrite bool) (e error) {
+	info, statError := os.Stat(path)
+	if statError != nil  {
+		if !os.IsNotExist(statError) {
+			return statError
+		}
+
+		if err := os.MkdirAll(path, 0700); err != nil {
+			return err
+		}
+	}
+
+	if info != nil && !info.IsDir() {
+		return errors.New(fmt.Sprintf("provided path pointed to file %s", path))
+	}
+
+	if directory.Parent() != nil { // If the directory is not a root directory, we want to create the directory
+		path = filepath.Join(path , directory.Name().String())
+	}
+
+	return writeDirectoryToDisk(directory , path , overwrite)
+}
+
+func writeFileToDisk(file File, directoryPath string, overwrite bool) (e error) {
+	path := filepath.Join(directoryPath, file.Name().String())
+	var fileOnDisk *os.File
+
+	info, e := os.Stat(path)
+	if e != nil { // Checking if statistics for path cannot be found
+		if !os.IsNotExist(e) { // Checking if the path does exist but couldn't be accessed
+			return e
+		}
+
+		if fileOnDisk, e = os.Create(path); e != nil { // Creating the path given that it doesn't exist
+			return e
+		}
+	}
+
+	if info != nil { // Checking if the path currently exists
+		if info.IsDir() { // Checking if the path is a directory
+			return errors.New(fmt.Sprintf("provided path pointed to directory %s", path))
+		}
+
+		if !overwrite { // Checking if the file should be overwritten given it exists
+			return nil
+		}
+	}
+
+	if fileOnDisk, e = os.OpenFile(path, os.O_RDWR|os.O_TRUNC, 0700);  e != nil {
+		// Check for errors after opening the file
+		return  e
+	}
+
+	if err := file.CopyContent(fileOnDisk); err != nil {
+		// Check for errors after writing the given file to the disk file
+		return err
+	}
+
+	if err := fileOnDisk.Close(); err != nil {
+		// Checking for errors while closing the disk file
+		return err
+	}
+	return nil
+}
+
+func writeDirectoryToDisk(directory Directory, directoryPath string, overwrite bool) (e error) {
+	info, e := os.Stat(directoryPath)
+	if e != nil {
+		if !os.IsNotExist(e) {
+			return e
+		}
+
+		if e := os.MkdirAll(directoryPath, 0700); e != nil {
+			return e
+		}
+	}
+
+	if info != nil && !info.IsDir() {
+		return errors.New(fmt.Sprintf("provided path pointed to file %s", directoryPath))
+	}
+
+	for _, dir := range directory.Directories() {
+		if err := writeDirectoryToDisk(dir, filepath.Join(directoryPath, dir.Name().String()), overwrite); err != nil {
+			return err
+		}
+	}
+
+	for _, file := range directory.Files() {
+		if err := writeFileToDisk(file, directoryPath, overwrite); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
Writes a virtual directory to the disk to improve assets storing on
disk. Checks if the directory is a root directory in which case it will
write everything in the directory to the path. If not the WriteToDisk
method will first create a sub-directory in the path, in which it stores
the contents of the passed virtual directory.

This fixes #6 
