### PR TITLE
Removes the need to specify the package

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,11 @@ import (
 var TestInjectionPoint TestInterface
 
 // TestInterface is a testing interface for Pina-Golada. This interface will be implemented by Pina-Golada.
-// The package name has to match the package name in which this interface is found, the injector is the name of an exported
-// variable of the type of this interface. The instance of the compiled struct, implementing this interface, will stored in
-// the variable provided in the annotation below.
-// @pgl(package=test&injector=TestInjectionPoint)
+// The injector is the name of an exported variable of the type of this interface.
+// The instance of the compiled struct, implementing this interface, will stored in the variable provided in the
+// annotation below.
+//
+// @pgl(injector=TestInjectionPoint)
 type TestInterface interface {
 	
 	// GetAssetFile is the method that returns a virtual asset stored in the directory instance.

--- a/internal/golada/builder/builder.go
+++ b/internal/golada/builder/builder.go
@@ -42,7 +42,6 @@ var (
 
 // PinaGoladaInterface is the struct used for the pina golada interface annotation
 type PinaGoladaInterface struct {
-	Package  string `yaml:"package"`
 	Injector string `yaml:"injector"`
 }
 
@@ -77,14 +76,11 @@ func NewBuilder(target *inspector.AstInterface, interfaceAnnotation *PinaGoladaI
 
 // BuildFile Builds the file
 func (b Builder) BuildFile() (by []byte, err error) {
-	if len(b.interfaceAnnotation.Package) < 1 {
-		return nil, errors.New("no package defined on " + b.target.Name.Name)
-	}
 	if len(b.interfaceAnnotation.Injector) < 1 {
 		return nil, errors.New("no injector variable defined on " + b.target.Name.Name)
 	}
 
-	goGenerator := generator.NewFileGoGenerator(b.interfaceAnnotation.Package)
+	goGenerator := generator.NewFileGoGenerator(b.target.File.FileReference.Name.Name)
 	structName := "PGL" + b.target.Name.Name
 	receiverType := "p *" + structName
 

--- a/internal/golada/builder/builder_test.go
+++ b/internal/golada/builder/builder_test.go
@@ -21,6 +21,7 @@
 package builder
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -58,12 +59,12 @@ var _ = Describe("should generate files correctly", func() {
 		Expect(len(interfaces)).To(BeEquivalentTo(1))
 
 		builder := NewBuilder(interfaces[0], &PinaGoladaInterface{
-			Package:  "builder",
 			Injector: "AssetInjector",
 		}, annotation.NewPropertyParser())
 		b, e := builder.BuildFile()
 
 		Expect(e).To(BeNil())
 		Expect(b).To(Not(BeNil()))
+		fmt.Println(string(b)) // Printing it to the test console to manually debug builder errors
 	})
 })

--- a/internal/golada/cmd/generate.go
+++ b/internal/golada/cmd/generate.go
@@ -93,13 +93,13 @@ func Generate(path string, parser annotation.Parser) {
 			log.Fatalf("Could not build file due to " + e.Error())
 		}
 		baseFileName := filepath.Base(i.Name.Name) + ".go"
-		implementationFileName := filepath.Join(filepath.Dir(i.File.Path), "pgl"+baseFileName)
+		implementationFileName := filepath.Join(filepath.Dir(i.File.OSFile.Path), "pgl"+baseFileName)
 		if err := ioutil.WriteFile(implementationFileName, output, os.ModePerm); err != nil {
 			log.Fatal("could not create output file due to " + err.Error())
 		}
 
 		_, _ = bunt.Printf("Aqua{%s}➤ Generated asset provider for LimeGreen{%s}\n", "Pina-Golada",
-			i.File.FileInfo.Name()+"#"+i.Name.Name)
+			i.File.OSFile.FileInfo.Name()+"#"+i.Name.Name)
 	}
 }
 

--- a/pkg/inspector/ast_inspector_test.go
+++ b/pkg/inspector/ast_inspector_test.go
@@ -56,5 +56,7 @@ var _ = Describe("Testing default ast stream functionality", func() {
 		Expect(methods.NumFields()).To(BeEquivalentTo(1))
 		Expect(methods.List[0].Doc.Text()).To(ContainSubstring("Foo test"))
 
+		Expect(foundInterface.File.FileReference.Name.Name).To(BeEquivalentTo("inspector"))
+		Expect(foundInterface.File.OSFile.FileInfo.Name()).To(BeEquivalentTo("ast_inspector_test.go"))
 	})
 })


### PR DESCRIPTION
This commit removes the need to specify the package by catching the
ast.File node in the astStream. The File node is then passed in a
wrapper instance to the interfaces. The astStream now processes nodes by
File rather than by order. The README was adapted to these changes.

This fixes #3 
