### PR TITLE
Hotfix: Enables custom permission for writing files onto the disk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,6 @@ analysis:
 	@scripts/analysis.sh
 
 test:
-	@shellcheck scripts/*.sh
 	@scripts/test.sh
 
 build:

--- a/pkg/files/files_util.go
+++ b/pkg/files/files_util.go
@@ -84,14 +84,14 @@ func readFileInto(directory Directory, path string) (e error) {
 
 // WriteToDisk writes a directory to the given path
 // Overwriting or skipping an existing file based on the bool
-func WriteToDisk(directory Directory, path string, overwrite bool) (e error) {
+func WriteToDisk(directory Directory, path string, overwrite bool, permission os.FileMode) (e error) {
 	info, statError := os.Stat(path)
-	if statError != nil  {
+	if statError != nil {
 		if !os.IsNotExist(statError) {
 			return statError
 		}
 
-		if err := os.MkdirAll(path, 0700); err != nil {
+		if err := os.MkdirAll(path, permission); err != nil {
 			return err
 		}
 	}
@@ -101,13 +101,13 @@ func WriteToDisk(directory Directory, path string, overwrite bool) (e error) {
 	}
 
 	if directory.Parent() != nil { // If the directory is not a root directory, we want to create the directory
-		path = filepath.Join(path , directory.Name().String())
+		path = filepath.Join(path, directory.Name().String())
 	}
 
-	return writeDirectoryToDisk(directory , path , overwrite)
+	return writeDirectoryToDisk(directory, path, overwrite, permission)
 }
 
-func writeFileToDisk(file File, directoryPath string, overwrite bool) (e error) {
+func writeFileToDisk(file File, directoryPath string, overwrite bool, permission os.FileMode) (e error) {
 	path := filepath.Join(directoryPath, file.Name().String())
 	var fileOnDisk *os.File
 
@@ -132,9 +132,9 @@ func writeFileToDisk(file File, directoryPath string, overwrite bool) (e error) 
 		}
 	}
 
-	if fileOnDisk, e = os.OpenFile(path, os.O_RDWR|os.O_TRUNC, 0700);  e != nil {
+	if fileOnDisk, e = os.OpenFile(path, os.O_RDWR|os.O_TRUNC, permission); e != nil {
 		// Check for errors after opening the file
-		return  e
+		return e
 	}
 
 	if err := file.CopyContent(fileOnDisk); err != nil {
@@ -149,14 +149,14 @@ func writeFileToDisk(file File, directoryPath string, overwrite bool) (e error) 
 	return nil
 }
 
-func writeDirectoryToDisk(directory Directory, directoryPath string, overwrite bool) (e error) {
+func writeDirectoryToDisk(directory Directory, directoryPath string, overwrite bool, permission os.FileMode) (e error) {
 	info, e := os.Stat(directoryPath)
 	if e != nil {
 		if !os.IsNotExist(e) {
 			return e
 		}
 
-		if e := os.MkdirAll(directoryPath, 0700); e != nil {
+		if e := os.MkdirAll(directoryPath, permission); e != nil {
 			return e
 		}
 	}
@@ -166,13 +166,13 @@ func writeDirectoryToDisk(directory Directory, directoryPath string, overwrite b
 	}
 
 	for _, dir := range directory.Directories() {
-		if err := writeDirectoryToDisk(dir, filepath.Join(directoryPath, dir.Name().String()), overwrite); err != nil {
+		if err := writeDirectoryToDisk(dir, filepath.Join(directoryPath, dir.Name().String()), overwrite, permission); err != nil {
 			return err
 		}
 	}
 
 	for _, file := range directory.Files() {
-		if err := writeFileToDisk(file, directoryPath, overwrite); err != nil {
+		if err := writeFileToDisk(file, directoryPath, overwrite, permission); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
This commit adds the parameter permission to the WriteToDisk method
as the permissions the files are created with, should be determined by
the executing program not pina-golada.

Note: I will merge this on my own as it is currently preventing me from working on watchful and the change is not big at all.