### PR TITLE
Introduces Directory#AsRoot to create a root copy

### DIFF
--- a/pkg/compressor/compressor_tar.go
+++ b/pkg/compressor/compressor_tar.go
@@ -46,7 +46,7 @@ func (t *Tar) Compress(directory files.Directory, writer *bytes.Buffer) (e error
 
 		tarHeader := &tar.Header{
 			Name:     filepath.ToSlash(file.AbsolutePath().String()),
-			Mode:     0700,
+			Mode:     int64(file.PermissionSet()),
 			Size:     int64(buffer.Len()),
 			Typeflag: tar.TypeReg,
 		}
@@ -87,7 +87,7 @@ func (t *Tar) Decompress(reader io.Reader) (directory files.Directory, e error) 
 			break
 		}
 
-		if err := root.NewFile(paths.Of(header.Name)).Write(tarReader); err != nil {
+		if err := root.NewFile(paths.Of(header.Name)).WithPermission(header.FileInfo().Mode()).Write(tarReader); err != nil {
 			foundError = err
 			break
 		}

--- a/pkg/files/files.go
+++ b/pkg/files/files.go
@@ -23,6 +23,7 @@ package files
 import (
 	"io"
 	"io/ioutil"
+	"os"
 
 	"github.com/homeport/pina-golada/pkg/files/paths"
 )
@@ -40,6 +41,9 @@ type File interface {
 	Name() (name paths.Path)
 	AbsolutePath() (path paths.Path)
 
+	WithPermission(set os.FileMode) File
+	PermissionSet() os.FileMode
+
 	CopyContent(writer io.Writer) (e error)
 	Write(reader io.Reader) (e error)
 	WriteFlagged(reader io.Reader, append bool) (e error)
@@ -50,9 +54,10 @@ type File interface {
 
 // memoryFile is an in memory implementation of the File interface
 type memoryFile struct {
-	name    paths.Path
-	parent  Directory
-	content []byte
+	name     paths.Path
+	parent   Directory
+	content  []byte
+	PermBits os.FileMode
 }
 
 // Name Returns the name of the file
@@ -99,4 +104,15 @@ func (m *memoryFile) Delete() {
 // Parent returns the parent of the file
 func (m *memoryFile) Parent() (parentDirectory Directory) {
 	return m.parent
+}
+
+// WithPermission stores the permission set on the directory
+func (m *memoryFile) WithPermission(set os.FileMode) File {
+	m.PermBits = set
+	return m
+}
+
+// PermissionSet returns the permission set of the directory
+func (m *memoryFile) PermissionSet() os.FileMode {
+	return m.PermBits
 }

--- a/pkg/files/files_test.go
+++ b/pkg/files/files_test.go
@@ -150,6 +150,12 @@ var _ = Describe("should handle files properly", func() {
 		Expect(buffer.String()).To(BeEquivalentTo("test"))
 	})
 
+	_ = It("should create an asRoot copy", func() {
+		root.NewDirectory(paths.Of("usr")).NewDirectory(paths.Of("homeport")).NewDirectory(paths.Of("home")).NewFile(paths.Of("test.go"))
+		rootCopy := root.Directory(paths.Of("usr/homeport")).AsRoot()
+		Expect(rootCopy.File(paths.Of("home/test.go"))).To(Not(BeNil()))
+	})
+
 	_ = It("should read from file correctly", func() {
 		e := LoadFromDisk(root, filepath.FromSlash("../../assets/tests"))
 		Expect(e).To(BeNil())


### PR DESCRIPTION
As a sub directory may be used as a base for future operations, creating
a rooted copy of it, helps.

This also allows to copy only a directories content if the directory is
not the root directory