### PR TITLE
Fixes open file writer instance on WriteToDisk

### DIFF
--- a/pkg/files/files_util.go
+++ b/pkg/files/files_util.go
@@ -122,7 +122,11 @@ func writeFileToDisk(file File, directoryPath string, overwrite bool) (e error) 
 			return e
 		}
 
-		if fileOnDisk, e = os.Create(path); e != nil { // Creating the path given that it doesn't exist
+		if fileOnDisk, e = os.Create(path); e == nil { // Creating the path given that it doesn't exist
+			if err := fileOnDisk.Close(); err != nil {
+				return err
+			}
+		} else {
 			return e
 		}
 	}


### PR DESCRIPTION
When writing a file to the file system using WriteToDisk, the file
writer instance that is created when creating the file from scratch is
now being closed, allowing the program instantly work on the written
file