### PR TITLE
Adds default permission to files

### DIFF
--- a/pkg/files/directory.go
+++ b/pkg/files/directory.go
@@ -149,8 +149,9 @@ func (m *memoryDirectory) NewFile(path paths.Path) (newFile File) {
 	}
 
 	file := &memoryFile{
-		parent: m,
-		name:   newPath,
+		parent:   m,
+		name:     newPath,
+		PermBits: os.FileMode(0755),
 	}
 	file.WithPermission(m.PermissionSet())
 	m.files = append(m.files, file)
@@ -239,6 +240,7 @@ func (m *memoryDirectory) NewDirectory(path paths.Path) (newDirectory Directory)
 	createdDirectory := &memoryDirectory{
 		name:   path,
 		parent: m,
+		PermBits: os.FileMode(0755),
 	}
 	createdDirectory.WithPermission(m.PermissionSet())
 
@@ -308,6 +310,7 @@ func copyDirectory(original Directory, new Directory) error {
 // NewRootDirectory returns a new root directory
 func NewRootDirectory() Directory {
 	return &memoryDirectory{
-		name: paths.RootPath(),
+		name:     paths.RootPath(),
+		PermBits: os.FileMode(0755),
 	}
 }


### PR DESCRIPTION
When creating files/directories that don't have a permission set
assigned, due to compression mechanism etc, pina-golada will now
automatically assign 0755 as the default file permission instead of 0000