### PR TITLE
Add Go version 1.12 to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@
 language: go
 go:
   - 1.11.x
+  - 1.12.x
 
 install:
   - curl -sL https://goo.gl/g1CpPX | bash -s v1.0.5 # Golang dev tools including pre-compiled Ginkgo and other useful tools


### PR DESCRIPTION
Add Go version 1.12 as one of the Go versions to be tested.