### PR TITLE
remove -v in ginkgo #18

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -29,5 +29,4 @@ GO111MODULE=on ginkgo -r \
   --nodes=4 \
   --compilers=2 \
   --race \
-  --trace \
-  -v
+  --trace


### PR DESCRIPTION
fix #18 
I fixed the script/test.sh to be disable verbose ginkgo to remove`-v` option