### PR TITLE
Ensure that import paths are only used once

### DIFF
--- a/assets/tests/issue-27/directory-1/info.txt
+++ b/assets/tests/issue-27/directory-1/info.txt
@@ -1,0 +1,1 @@
+Just another example file.

--- a/assets/tests/issue-27/directory-2/info.txt
+++ b/assets/tests/issue-27/directory-2/info.txt
@@ -1,0 +1,1 @@
+Just another example file.

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -104,7 +104,20 @@ func (f *FileGoGenerator) Flush(writer io.Writer) {
 
 // Import adds a new import to the generator
 func (f *FileGoGenerator) Import(importName string) GoGenerator {
-	f.imports = append(f.imports, importName)
+	contains := func(list []string, value string) bool {
+		for _, entry := range list {
+			if entry == value {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	if !contains(f.imports, importName) {
+		f.imports = append(f.imports, importName)
+	}
+
 	return f
 }
 


### PR DESCRIPTION
Replace list of import paths with a simple map structure, where the keys are
the import paths to be used. This way, there is no need to check whether an
import path was already used.

This should fix issue #27.