### PR TITLE
Omit parenthesis if generated function has no return value

### DIFF
--- a/internal/golada/builder/builder_test.go
+++ b/internal/golada/builder/builder_test.go
@@ -67,4 +67,24 @@ var _ = Describe("should generate files correctly", func() {
 		Expect(b).To(Not(BeNil()))
 		fmt.Println(string(b)) // Printing it to the test console to manually debug builder errors
 	})
+
+	_ = It("should not write starting and closing parenthesis for a function with no return type", func() {
+		stream, e := inspector.NewFileStream("./")
+		Expect(e).To(BeNil())
+
+		astStream := inspector.NewAstStream(stream.Filter(func(file inspector.File) bool {
+			return strings.Contains(file.FileInfo.Name(), "builder_test.go")
+		}))
+		interfaces := astStream.Find()
+		Expect(len(interfaces)).To(BeEquivalentTo(1))
+
+		builder := NewBuilder(interfaces[0], &PinaGoladaInterface{
+			Injector: "AssetInjector",
+		}, annotation.NewPropertyParser())
+		b, e := builder.BuildFile()
+
+		Expect(e).To(BeNil())
+		Expect(b).To(Not(BeNil()))
+		Expect(strings.Count(string(b), "func init() ()")).To(BeEquivalentTo(0))
+	})
 })

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -204,14 +204,27 @@ func (m *SimpleMethodGenerator) Body(body ...string) MethodGenerator {
 // Flush flushes the content of the generator to a writer instance
 func (m *SimpleMethodGenerator) Flush(writer io.Writer) {
 	builder := &strings.Builder{}
+
+	// function definition with optional receiver
 	builder.WriteString("func ")
 	if len(m.receiver) > 0 {
 		builder.WriteString("(" + m.receiver + ") ")
 	}
-	builder.WriteString(m.name + "(" + strings.Join(m.parameters, ", ") + ") (" + strings.Join(m.returnTypes, ", ") + ") {" + EndOfLine)
+
+	// function name and function parameters
+	builder.WriteString(m.name + "(" + strings.Join(m.parameters, ", ") + ")")
+
+	// function return types (if any)
+	if len(m.returnTypes) > 0 {
+		builder.WriteString(" (" + strings.Join(m.returnTypes, ", ") + ")")
+	}
+
+	// function body
+	builder.WriteString(" {" + EndOfLine)
 	for _, body := range m.body {
 		builder.WriteString(Intend + body + EndOfLine)
 	}
 	builder.WriteString("}" + EndOfLine)
-	_, _ = writer.Write([]byte(builder.String()))
+
+	writer.Write([]byte(builder.String()))
 }


### PR DESCRIPTION
Break up the function write code to add a condition to only add return
types in parenthesis if there are ones defined.

This should fix issue #29.