### PR TITLE
Run Go Formatter on generated source

### DIFF
--- a/internal/golada/builder/builder.go
+++ b/internal/golada/builder/builder.go
@@ -25,6 +25,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"go/format"
 	"path/filepath"
 	"strings"
 
@@ -152,5 +153,6 @@ func (b Builder) BuildFile() (by []byte, err error) {
 	outputBuffer := &bytes.Buffer{}
 	outputBuffer.WriteString(IdentifierString + "\n")
 	goGenerator.Flush(outputBuffer)
-	return outputBuffer.Bytes(), nil
+
+	return format.Source(outputBuffer.Bytes())
 }


### PR DESCRIPTION
Run the Go formatter code on the generated source code. This increases the
readability if one ever choose to look at the code. Also, it serves as a
simple proof point whether the code is actual compilable Go source code.