### PR TITLE
Bugfix/directory permission

### DIFF
--- a/assets/tests/issue-35/subdirectory-1/nested-directory-1/example.txt
+++ b/assets/tests/issue-35/subdirectory-1/nested-directory-1/example.txt
@@ -1,0 +1,1 @@
+Nothing to see here, move on.

--- a/assets/tests/issue-35/subdirectory-1/nested-directory-2/example.txt
+++ b/assets/tests/issue-35/subdirectory-1/nested-directory-2/example.txt
@@ -1,0 +1,1 @@
+Nothing to see here, move on.

--- a/assets/tests/issue-35/subdirectory-2/example.txt
+++ b/assets/tests/issue-35/subdirectory-2/example.txt
@@ -1,0 +1,1 @@
+Nothing to see here, move on.

--- a/pkg/files/files_util.go
+++ b/pkg/files/files_util.go
@@ -41,6 +41,14 @@ func WalkFileTree(directory Directory, consumer func(file File)) {
 	}
 }
 
+// WalkDirectoryTree walks over each sub directory found in the directory, excluding the passed directory
+func WalkDirectoryTree(directory Directory, consumer func(d Directory)) {
+	for _, dir := range directory.Directories() {
+		consumer(dir)
+		WalkDirectoryTree(dir, consumer)
+	}
+}
+
 // LoadFromDisk Loads the content of the paths into the directory recursively
 func LoadFromDisk(directory Directory, path string) (e error) {
 	info, statError := os.Stat(path)


### PR DESCRIPTION
As it turns out, pina-golada simply was not writing the directories itself as tarheaders, resulting in them not being recovered on depress.

This PR fixes #35 