### PR TITLE
Adds verbose output option

### DIFF
--- a/internal/golada/builder/builder.go
+++ b/internal/golada/builder/builder.go
@@ -25,6 +25,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"github.com/homeport/pina-golada/internal/golada/logger"
 	"go/format"
 	"path/filepath"
 	"strings"
@@ -71,11 +72,15 @@ type Builder struct {
 	target              *inspector.AstInterface
 	interfaceAnnotation *PinaGoladaInterface
 	parser              annotation.Parser
+	logger              logger.Logger
 }
 
 // NewBuilder Creates a new builder instance
-func NewBuilder(target *inspector.AstInterface, interfaceAnnotation *PinaGoladaInterface, parser annotation.Parser) *Builder {
-	return &Builder{target: target, interfaceAnnotation: interfaceAnnotation, parser: parser}
+func NewBuilder(target *inspector.AstInterface,
+	interfaceAnnotation *PinaGoladaInterface,
+	parser annotation.Parser,
+	l logger.Logger) *Builder {
+	return &Builder{target: target, interfaceAnnotation: interfaceAnnotation, parser: parser, logger: l}
 }
 
 // BuildFile Builds the file
@@ -120,6 +125,10 @@ func (b Builder) BuildFile() (by []byte, err error) {
 			return nil, e
 		}
 
+		files.WalkFileTree(directory, func(file files.File) {
+			b.logger.Debug("Gray{Debug➤ Found asset file} White{%s}", file.Name().String())
+		})
+
 		compressorType := compressor.DefaultRegistry.Find(methodAnnotation.Compressor)
 		if compressorType == nil {
 			return nil, errors.New("could not find compressor for " + methodAnnotation.Compressor)
@@ -128,6 +137,10 @@ func (b Builder) BuildFile() (by []byte, err error) {
 		if err := compressorType.Compress(directory, buffer); err != nil {
 			return nil, err
 		}
+
+		b.logger.Debug("Gray{Debug➤ Compressed asset} LimeGreen{%s} Gray{for method} LimeGreen{%s} "+
+			"Gray{to} LimeGreen{%d} Gray{bytes}",
+			methodAnnotation.Asset, b.target.Name.Name+"#"+methodName, buffer.Len())
 
 		goGenerator.Method(methodName, func(method generator.MethodGenerator) {
 			method.Receiver(receiverType).ReturnTypes("files.Directory", "error").Body([]string{
@@ -152,6 +165,7 @@ func (b Builder) BuildFile() (by []byte, err error) {
 	goGenerator.Method("init", func(method generator.MethodGenerator) {
 		method.Body(b.interfaceAnnotation.Injector + " = &" + structName + "{}")
 	})
+	b.logger.Debug("Gray{Debug➤ Generated initialize method for} LimeGreen{%s}", b.target.Name.Name)
 
 	outputBuffer := &bytes.Buffer{}
 	outputBuffer.WriteString(IdentifierString + "\n\n")

--- a/internal/golada/builder/builder_test.go
+++ b/internal/golada/builder/builder_test.go
@@ -21,6 +21,7 @@
 package builder
 
 import (
+	"github.com/homeport/pina-golada/internal/golada/logger"
 	"strings"
 	"testing"
 
@@ -53,6 +54,15 @@ type AssetProvider interface {
 }
 
 var _ = Describe("should generate files correctly", func() {
+
+	var (
+		l logger.Logger
+	)
+
+	_ = BeforeEach(func() {
+		l = logger.NewDefaultLogger(&DevNullWriter{}, logger.Debug)
+	})
+
 	_ = It("should create a compilable file", func() {
 		stream, e := inspector.NewFileStream("./")
 		Expect(e).To(BeNil())
@@ -65,7 +75,7 @@ var _ = Describe("should generate files correctly", func() {
 
 		builder := NewBuilder(interfaces[0], &PinaGoladaInterface{
 			Injector: "AssetInjector",
-		}, annotation.NewPropertyParser())
+		}, annotation.NewPropertyParser(), l)
 		b, e := builder.BuildFile()
 
 		Expect(e).To(BeNil())
@@ -91,6 +101,7 @@ var _ = Describe("should generate files correctly", func() {
 				Injector: "AssetInjector",
 			},
 			annotation.NewPropertyParser(),
+			l,
 		)
 
 		b, err := builder.BuildFile()
@@ -112,7 +123,7 @@ var _ = Describe("should generate files correctly", func() {
 
 		builder := NewBuilder(interfaces[0], &PinaGoladaInterface{
 			Injector: "AssetInjector",
-		}, annotation.NewPropertyParser())
+		}, annotation.NewPropertyParser(), l)
 		b, e := builder.BuildFile()
 
 		Expect(e).To(BeNil())

--- a/internal/golada/builder/builder_test_suite.go
+++ b/internal/golada/builder/builder_test_suite.go
@@ -1,0 +1,32 @@
+// MIT License
+//
+// Copyright (c) 2019 The Homeport Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package builder
+
+// DevNullWriter simply does nothing but implement writer
+type DevNullWriter struct {
+}
+
+// Write writes literally nothing
+func (DevNullWriter) Write(p []byte) (n int, err error) {
+	return 0, nil
+}

--- a/internal/golada/cmd/cleanup.go
+++ b/internal/golada/cmd/cleanup.go
@@ -22,6 +22,7 @@ package cmd
 
 import (
 	"bufio"
+	"github.com/homeport/pina-golada/internal/golada/logger"
 	"log"
 	"os"
 	"path/filepath"
@@ -37,6 +38,13 @@ var cleanupCommand = &cobra.Command{
 	Short: "Cleans all the generated files",
 	Long:  "Cleanup will iterate over every go file in the project and delete it if it does start with PinaGolada's identifier string",
 	Run: func(c *cobra.Command, args []string) {
+		var l logger.Logger
+		if verbose {
+			l = logger.NewDefaultLogger(os.Stdout, logger.Debug)
+		} else {
+			l = logger.NewDefaultLogger(os.Stdout, logger.Info)
+		}
+
 		e := filepath.Walk(".", func(path string, info os.FileInfo, err error) error {
 			if GoFileSelector.Match([]byte(info.Name())) {
 				file, err := os.Open(path)
@@ -58,6 +66,7 @@ var cleanupCommand = &cobra.Command{
 					if err := os.Remove(path); err != nil {
 						return err
 					}
+					l.Debug("Gray{Debug➤ Removed pina-golada file} LimeGreen{%s}", file.Name())
 				}
 			}
 			return nil
@@ -65,9 +74,11 @@ var cleanupCommand = &cobra.Command{
 		if e != nil {
 			log.Fatalf("could not iterrate over the files in this directory %s", e.Error())
 		}
+		l.Info("Aqua{%s}➤ Cleaned project from pina-golada file", "Pina-Golada")
 	},
 }
 
 func init() {
+	cleanupCommand.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "--verbose|-v")
 	rootCmd.AddCommand(cleanupCommand)
 }

--- a/internal/golada/cmd/root.go
+++ b/internal/golada/cmd/root.go
@@ -27,6 +27,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	verbose bool
+)
+
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "pina-golada",

--- a/internal/golada/logger/bunt_logger.go
+++ b/internal/golada/logger/bunt_logger.go
@@ -1,0 +1,87 @@
+// MIT License
+//
+// Copyright (c) 2019 The Homeport Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package logger
+
+import (
+	"fmt"
+	"github.com/homeport/gonvenience/pkg/v1/bunt"
+	"io"
+	"strings"
+)
+
+// LogLevel defines the type of level the logger will log at
+type LogLevel uint32
+
+const (
+	// Info defines the info level which will always be printed
+	Info LogLevel = iota
+
+	// Debug defines the debug level which will be printed
+	Debug
+)
+
+// Logger defines a logger that prints strings to the general output
+//
+// Log logs the message with the given log level
+//
+// Info logs the message on the info level
+//
+// Debug logs the message on the debug level
+type Logger interface {
+	Log(level LogLevel, message string, a ...interface{})
+	Info(message string, a ...interface{})
+	Debug(message string, a ...interface{})
+}
+
+// DefaultLogger defines the default logger implementation
+type DefaultLogger struct {
+	outputStream    io.Writer
+	highestLogLevel LogLevel
+}
+
+// NewDefaultLogger creates a new default logger
+func NewDefaultLogger(outputStream io.Writer, highestLogLevel LogLevel) *DefaultLogger {
+	return &DefaultLogger{outputStream: outputStream, highestLogLevel: highestLogLevel}
+}
+
+// Log logs the message with the given log level
+func (d *DefaultLogger) Log(level LogLevel, message string, a ...interface{}) {
+	if d.highestLogLevel >= level {
+		message := bunt.Sprintf(message, a...)
+		if !strings.HasSuffix(message , "\n") {
+			message += "\n"
+		}
+
+		fmt.Fprint(d.outputStream, message)
+	}
+}
+
+// Info logs the message on the info level
+func (d *DefaultLogger) Info(message string, a ...interface{}) {
+	d.Log(Info, message, a...)
+}
+
+// Debug logs the message on the debug level
+func (d *DefaultLogger) Debug(message string, a ...interface{}) {
+	d.Log(Debug, message, a...)
+}


### PR DESCRIPTION
This commit adds the verbose option by passing a logger instance to the
executing object. The verbose option displays files as well as found
asset files when executed.

This fixed #38.

This pr currently implements the verbose output I personally feel needed. 
If you have more / different needs, please comment below.