### PR TITLE
Now overwrites file and directory permissions

### DIFF
--- a/assets/tests/issue-51/file/permission.txt
+++ b/assets/tests/issue-51/file/permission.txt
@@ -1,0 +1,1 @@
+This file is mainly for testing permissions

--- a/pkg/files/files_test.go
+++ b/pkg/files/files_test.go
@@ -22,6 +22,7 @@ package files
 
 import (
 	"bytes"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -169,4 +170,42 @@ var _ = Describe("should handle files properly", func() {
 
 		Expect(strings.Replace(buffer.String(), "\r", "", -1)).To(BeEquivalentTo("test\n")) // remove \r from windows
 	})
+
+	_ = It("should overwrite permission sets on files", func() {
+		pathToTestDir := "../../assets/tests/issue-51/file"
+		pathToTestFile := filepath.Join(pathToTestDir, "permission.txt")
+
+		os.Chmod(pathToTestFile, 0777)
+		Expect(GetFilePermission(pathToTestFile)).To(BeEquivalentTo(0777))
+
+		Expect(LoadFromDisk(root, pathToTestDir)).To(BeNil())
+		file := root.File(paths.Of("permission.txt"))
+		Expect(file).To(Not(BeNil()))
+
+		file.WithPermission(os.FileMode(0701))
+		Expect(WriteToDisk(root, pathToTestDir, true)).To(BeNil())
+		Expect(GetFilePermission(pathToTestFile)).To(BeEquivalentTo(os.FileMode(0701)))
+	})
+
+	_ = It("should overwrite permission sets on folders", func() {
+		pathToTestDir := "../../assets/tests/issue-51/folder"
+		pathToTestFile := filepath.Join(pathToTestDir, "permission")
+
+		Expect(os.Chmod(pathToTestFile, 0777)).To(Not(HaveOccurred()))
+		Expect(GetFilePermission(pathToTestFile).Perm()).To(BeEquivalentTo(0777))
+
+		Expect(LoadFromDisk(root, pathToTestDir)).To(BeNil())
+		directory := root.Directory(paths.Of("permission"))
+		Expect(directory).To(Not(BeNil()))
+
+		directory.WithPermission(0701)
+		Expect(WriteToDisk(root, pathToTestDir, true)).To(BeNil())
+		Expect(GetFilePermission(pathToTestFile).Perm()).To(BeEquivalentTo(0701))
+	})
 })
+
+func GetFilePermission(path string) os.FileMode {
+	info, e := os.Stat(path)
+	Expect(e).To(Not(HaveOccurred()))
+	return info.Mode()
+}

--- a/pkg/files/files_test.go
+++ b/pkg/files/files_test.go
@@ -175,7 +175,7 @@ var _ = Describe("should handle files properly", func() {
 		pathToTestDir := "../../assets/tests/issue-51/file"
 		pathToTestFile := filepath.Join(pathToTestDir, "permission.txt")
 
-		os.Chmod(pathToTestFile, 0777)
+		Expect(os.Chmod(pathToTestFile, 0777)).To(Not(HaveOccurred()))
 		Expect(GetFilePermission(pathToTestFile)).To(BeEquivalentTo(0777))
 
 		Expect(LoadFromDisk(root, pathToTestDir)).To(BeNil())
@@ -187,12 +187,12 @@ var _ = Describe("should handle files properly", func() {
 		Expect(GetFilePermission(pathToTestFile)).To(BeEquivalentTo(os.FileMode(0701)))
 	})
 
-	_ = It("should overwrite permission sets on folders", func() {
-		pathToTestDir := "../../assets/tests/issue-51/folder"
-		pathToTestFile := filepath.Join(pathToTestDir, "permission")
+	_ = It("should overwrite permission sets on directories", func() {
+		pathToTestDir := "../../assets/tests/issue-51/directory"
+		pathToTestTarget := filepath.Join(pathToTestDir, "permission")
 
-		Expect(os.Chmod(pathToTestFile, 0777)).To(Not(HaveOccurred()))
-		Expect(GetFilePermission(pathToTestFile).Perm()).To(BeEquivalentTo(0777))
+		Expect(os.Chmod(pathToTestTarget, 0777)).To(Not(HaveOccurred()))
+		Expect(GetFilePermission(pathToTestTarget).Perm()).To(BeEquivalentTo(0777))
 
 		Expect(LoadFromDisk(root, pathToTestDir)).To(BeNil())
 		directory := root.Directory(paths.Of("permission"))
@@ -200,7 +200,7 @@ var _ = Describe("should handle files properly", func() {
 
 		directory.WithPermission(0701)
 		Expect(WriteToDisk(root, pathToTestDir, true)).To(BeNil())
-		Expect(GetFilePermission(pathToTestFile).Perm()).To(BeEquivalentTo(0701))
+		Expect(GetFilePermission(pathToTestTarget).Perm()).To(BeEquivalentTo(0701))
 	})
 })
 


### PR DESCRIPTION
If overwrite is set to true when calling WriteToDisk, pina-golada now
overwrites the file permission set if it does not match the one of the
virtual file system.

This push request fixes #51 