### PR TITLE
Implements a go build-tag like annotation parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ In case your Go project needs assets packaged into your program, you can use `pi
 package assets
 
 import (
-  "github.com/homeport/pina-golada/pkg/files"
+ "github.com/homeport/pina-golada/pkg/files"
 )
 
 // Provider is the provider instance to access the assets framework
@@ -62,6 +62,15 @@ type ProviderInterface interface {
 ```
 
 Prior to the build, run `pina-golada generate` to create a generated Go source file, which contains your assets. To clean up any generated file, use `pina-golada cleanup`. If you fancy more details, enable the verbose mode using `--verbose`. This works for `generate` as well as `cleanup`.
+In addition to the verbose parameter, you can specify the annotation `parser` you want to use by providing the parser tag value.
+Here are the currently supported `parser` values:
+
+- `property`
+    - Example: `@pgl(asset=/my/path&compressor=tar)`
+- `csv`
+    - Example: `@pgl(asset,/my/path;compressor,tar)`
+- `build-tag`
+    - Example: `+pgl asset,/my/path compressor,tar`   
 
 ## Contributing
 

--- a/internal/golada/builder/builder.go
+++ b/internal/golada/builder/builder.go
@@ -58,7 +58,7 @@ type PinaGoladaInterface struct {
 
 // GetIdentifier returns the identifier of the interface
 func (PinaGoladaInterface) GetIdentifier() string {
-	return "@pgl"
+	return "pgl"
 }
 
 // PinaGoladaMethod is the struct used for the pina golada interface annotation
@@ -70,7 +70,7 @@ type PinaGoladaMethod struct {
 
 // GetIdentifier returns the identifier of the interface
 func (PinaGoladaMethod) GetIdentifier() string {
-	return "@pgl"
+	return "pgl"
 }
 
 // Builder is able to build a file

--- a/internal/golada/cmd/cleanup.go
+++ b/internal/golada/cmd/cleanup.go
@@ -79,6 +79,6 @@ var cleanupCommand = &cobra.Command{
 }
 
 func init() {
-	cleanupCommand.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "--verbose|-v")
+	cleanupCommand.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "--verbose|-v. Adding this flag to the command will print debug messages for further inside.")
 	rootCmd.AddCommand(cleanupCommand)
 }

--- a/internal/golada/cmd/generate.go
+++ b/internal/golada/cmd/generate.go
@@ -67,6 +67,8 @@ var generateCommand = &cobra.Command{
 			parser = annotation.NewCsvParser()
 		case "property":
 			parser = annotation.NewPropertyParser()
+		case "build-tag":
+			parser = annotation.NewLabelParser()
 		default:
 			log.Fatal("could not find parser for parser type " + parserType)
 		}
@@ -120,7 +122,9 @@ func Generate(path string, parser annotation.Parser, logger logger.Logger) {
 }
 
 func init() {
-	generateCommand.PersistentFlags().StringVar(&parserType, "parser", "property", "parser [csv,property]")
-	generateCommand.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "--verbose|-v")
+	generateCommand.PersistentFlags().StringVarP(&parserType, "parser", "p", "property", "parser=[csv,property,build-tag]. "+
+		"This defines which annotation parser pina-golada will when generating the asset providers. "+
+		"Check the project README for annotation examples")
+	generateCommand.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "--verbose|-v. Adding this flag to the command will print debug messages for further inside.")
 	rootCmd.AddCommand(generateCommand)
 }

--- a/pkg/annotation/annotation.go
+++ b/pkg/annotation/annotation.go
@@ -31,7 +31,7 @@ var (
 	ErrTooManyAnnotations = errors.New("the annotation type was declared multiple times in the comment")
 
 	// ErrNoAnnotation is the error that is thrown when no annotations were found in the comment
-	ErrNoAnnotation = errors.New("the requested annotation type was not find in the comment")
+	ErrNoAnnotation = errors.New("the requested annotation type was not found in the comment")
 )
 
 // Parser is an interface that is capable of parsing an annotation based on a string.

--- a/pkg/annotation/annotation_test.go
+++ b/pkg/annotation/annotation_test.go
@@ -21,7 +21,6 @@
 package annotation
 
 import (
-	"log"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -41,7 +40,7 @@ type TestAnnotation struct {
 
 // Returns the test annotation identifier
 func (TestAnnotation) GetIdentifier() string {
-	return "@test"
+	return "test"
 }
 
 var _ = Describe("should parse annotations correctly", func() {
@@ -58,8 +57,8 @@ var _ = Describe("should parse annotations correctly", func() {
 
 	_ = It("should parse a normal annotation", func() {
 		if err := parser.Parse("@test(name,test;version,1)", annotation); err != nil {
-			log.Fatal(err)
 			Fail("failed due to " + err.Error())
+			return
 		}
 
 		Expect(annotation.SuperCoolName).To(BeEquivalentTo("test"))
@@ -71,12 +70,27 @@ var _ = Describe("should parse annotations correctly", func() {
 is a doc
 @test(name,test;version,2)
 More documentation`, annotation); err != nil {
-			log.Fatal(err)
 			Fail("failed due to " + err.Error())
+			return
 		}
 
 		Expect(annotation.SuperCoolName).To(BeEquivalentTo("test"))
 		Expect(annotation.Version).To(BeEquivalentTo(2))
+	})
+
+	_ = It("should load the annotation from a label comment", func() {
+		parser = NewLabelParser()
+		content := `Well this is the first line of the doc
+This is the second ?
+  +test name,test version,3
+This is just kinda the third line`
+		if err := parser.Parse(content, annotation); err != nil {
+			Fail("failed due to " + err.Error())
+			return
+		}
+
+		Expect(annotation.SuperCoolName).To(BeEquivalentTo("test"))
+		Expect(annotation.Version).To(BeEquivalentTo(3))
 	})
 
 	_ = It("should not find an annotation", func() {

--- a/pkg/annotation/csv_parser.go
+++ b/pkg/annotation/csv_parser.go
@@ -39,7 +39,7 @@ func NewCsvParser() *CsvParser {
 
 // Parse parses an annotation following the format of the CsvParser
 func (c *CsvParser) Parse(comment string, annotation Annotation) (e error) {
-	r := regexp.MustCompile(`.*` + annotation.GetIdentifier() + `\((.*)\).*`)
+	r := regexp.MustCompile(`.*@` + annotation.GetIdentifier() + `\((.*)\).*`)
 	result := r.FindAllStringSubmatch(comment, -1)
 	if len(result) < 1 {
 		return ErrNoAnnotation

--- a/pkg/annotation/label_parser.go
+++ b/pkg/annotation/label_parser.go
@@ -1,4 +1,6 @@
-// Copyright © 2019 The Homeport Team
+// MIT License
+//
+// Copyright (c) 2019 The Homeport Team
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -7,50 +9,48 @@
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
 //
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
 //
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 package annotation
 
 import (
+	"gopkg.in/yaml.v2"
 	"regexp"
 	"strings"
-
-	"gopkg.in/yaml.v2"
 )
 
-// PropertyParser is a csv implementation of the annotation parser.
-// It will parse the annotation following a csv format, where the key, value pairs are separated by a,
-type PropertyParser struct {
+// LabelParser defines a go-style label parser implementation
+type LabelParser struct {
 }
 
-// NewPropertyParser creates a new parser with the default typ registry
-func NewPropertyParser() *PropertyParser {
-	return &PropertyParser{}
+// NewLabelParser creates a new instance of the label parser
+func NewLabelParser() *LabelParser {
+	return &LabelParser{}
 }
 
-// Parse parses an annotation following the format of the PropertyParser
-func (p *PropertyParser) Parse(comment string, annotation Annotation) (e error) {
-	r := regexp.MustCompile(`.*@` + annotation.GetIdentifier() + `\((.*)\).*`)
+// Parse parses an annotation following the format of the LabelParser
+func (c *LabelParser) Parse(comment string, annotation Annotation) (e error) {
+	r := regexp.MustCompile(`(.*\n)*( )*\+` + annotation.GetIdentifier() + ` (.*)(\n.*)|($)`)
 	result := r.FindAllStringSubmatch(comment, -1)
 	if len(result) < 1 {
 		return ErrNoAnnotation
 	}
 
 	foundAnnotation := make(map[string]string)
-	s := result[0][1] // We want the second group
+	s := result[0][3] // We want the fourth group
 
-	keyValuePair := strings.Split(s, "&")
+	keyValuePair := strings.Split(s, " ")
 	for _, paired := range keyValuePair {
-		keyToValue := strings.Split(paired, "=")
+		keyToValue := strings.Split(paired, ",")
 		if len(keyValuePair) >= 2 {
 			foundAnnotation[keyToValue[0]] = keyToValue[1]
 		}
@@ -60,7 +60,6 @@ func (p *PropertyParser) Parse(comment string, annotation Annotation) (e error) 
 	if e != nil {
 		return e
 	}
-
 	removedQuotes := strings.Replace(string(out), "\"", "", -1)
 
 	if err := yaml.Unmarshal([]byte(removedQuotes), annotation); err != nil {


### PR DESCRIPTION
This commit adds the build-tag annotation parser, which is supposed to
provide the feel of a go tag instead of the java like annotations
pina-golada was using before. This commit also provides documentation on
how to specify the annotation parser on the command call.

This implements #39 