### PR TITLE
Fixes builder directory tree

### DIFF
--- a/internal/golada/builder/builder.go
+++ b/internal/golada/builder/builder.go
@@ -28,7 +28,9 @@ import (
 	"errors"
 	"fmt"
 	"github.com/homeport/pina-golada/internal/golada/logger"
+	"github.com/homeport/pina-golada/pkg/files/paths"
 	"go/format"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -147,7 +149,17 @@ func (b Builder) BuildFile() (by []byte, err error) {
 		}
 
 		directory := files.NewRootDirectory()
-		isDir, e := files.LoadFromDiskAndType(directory, methodAnnotation.Asset)
+		isDir := false
+
+		if i, e := os.Stat(methodAnnotation.Asset); e == nil {
+			// Create a sub directory inside if the target asset is a dir.
+			if i.IsDir() {
+				directory = directory.NewDirectory(paths.Of(i.Name()))
+				isDir = true
+			}
+		}
+
+		e := files.LoadFromDisk(directory, methodAnnotation.Asset)
 		if e != nil {
 			return nil, e
 		}

--- a/pkg/files/files_util.go
+++ b/pkg/files/files_util.go
@@ -184,12 +184,18 @@ func writeFileToDisk(file File, directoryPath string, overwrite bool) (e error) 
 
 func writeDirectoryToDisk(directory Directory, directoryPath string, overwrite bool) (e error) {
 	info, e := os.Stat(directoryPath)
+	permissionSet := directory.PermissionSet()
+
 	if e != nil {
 		if !os.IsNotExist(e) {
 			return e
 		}
 
-		if e := os.MkdirAll(directoryPath, directory.PermissionSet()); e != nil {
+		if e := os.MkdirAll(directoryPath, permissionSet); e != nil {
+			return e
+		}
+
+		if info, e = os.Stat(directoryPath); e != nil {
 			return e
 		}
 	}
@@ -198,8 +204,8 @@ func writeDirectoryToDisk(directory Directory, directoryPath string, overwrite b
 		return fmt.Errorf("provided path pointed to file %s", directoryPath)
 	}
 
-	if overwrite && info.Mode() != directory.PermissionSet() { // Overwrite permissions if overwrite is enabled
-		if err := os.Chmod(directoryPath, directory.PermissionSet()); err != nil {
+	if overwrite && info.Mode() != permissionSet { // Overwrite permissions if overwrite is enabled
+		if err := os.Chmod(directoryPath, permissionSet); err != nil {
 			return err
 		}
 	}

--- a/pkg/files/files_util.go
+++ b/pkg/files/files_util.go
@@ -51,17 +51,16 @@ func WalkDirectoryTree(directory Directory, consumer func(d Directory)) {
 
 // LoadFromDisk loads the content of the paths into the directory recursively
 func LoadFromDisk(directory Directory, path string) (e error) {
-	_, e = LoadFromDiskAndType(directory, path)
-	return e
+	return loadFromDisk(directory, path)
 }
 
-// LoadFromDiskAndType loads the content of the paths into the directory recursively.
+// loadFromDisk loads the content of the paths into the directory recursively.
 // This also returns true if the file located under the path is a directory or false
 // if the file at the path is a flat file.
-func LoadFromDiskAndType(directory Directory, path string) (isDir bool, e error) {
+func loadFromDisk(directory Directory, path string) (e error) {
 	info, statError := os.Stat(path)
 	if statError != nil {
-		return false, statError
+		return statError
 	}
 
 	if info.IsDir() {
@@ -69,27 +68,27 @@ func LoadFromDiskAndType(directory Directory, path string) (isDir bool, e error)
 
 		directoryContent, e := ioutil.ReadDir(path)
 		if e != nil {
-			return true, e
+			return e
 		}
 
 		for _, file := range directoryContent {
 			if file.IsDir() {
-				if err := LoadFromDisk(directory.NewDirectory(paths.Of(file.Name())).WithPermission(file.Mode()), filepath.Join(path, file.Name())); err != nil {
-					return true, err
+				if err := loadFromDisk(directory.NewDirectory(paths.Of(file.Name())).WithPermission(file.Mode()), filepath.Join(path, file.Name())); err != nil {
+					return err
 				}
 			} else {
 				if err := readFileInto(directory, filepath.Join(path, file.Name())); err != nil {
-					return true, err
+					return err
 				}
 			}
 		}
-		return true, nil
+		return nil
 	}
 
 	if err := readFileInto(directory, path); err != nil {
-		return false, err
+		return err
 	}
-	return false, nil
+	return nil
 }
 
 func readFileInto(directory Directory, path string) (e error) {


### PR DESCRIPTION
The builder used to have its own loader logic as it stores the folder to
load as a sub directory below the root diretory to keep the diretory
name present.

Now the builder does this prior to calling the default LoadFromDisk
method which fixes the lookup issues in the generated asset providers.

This PR fixes #59 