### PR TITLE
Implements integration test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 ---
 language: go
 go:
-  - 1.11.x
   - 1.12.x
 
 install:

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.3 // indirect
 	golang.org/x/net v0.0.0-20190311183353-d8887717615a // indirect
-	golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6 // indirect
+	golang.org/x/sync v0.0.0-20190423024810-112230192c58 // indirect
 	golang.org/x/sys v0.0.0-20190312061237-fead79001313 // indirect
 	golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect

--- a/go.sum
+++ b/go.sum
@@ -44,8 +44,8 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a h1:oWX7TPOiFAMXLq8o0ikBYfCJV
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f h1:wMNYb4v58l5UBM7MYRLPG6ZhfOqbKu7X5eyFl8ZhKvA=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6 h1:bjcUS9ztw9kFmmIxJInhon/0Is3p+EHBKNgquIzo1OI=
-golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181128092732-4ed8d59d0b35 h1:YAFjXN64LMvktoUZH9zgY4lGc/msGN7HQfoSuKCgaDU=
 golang.org/x/sys v0.0.0-20181128092732-4ed8d59d0b35/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/internal/golada/builder/builder.go
+++ b/internal/golada/builder/builder.go
@@ -165,6 +165,10 @@ func (b Builder) BuildFile() (by []byte, err error) {
 			return nil, e
 		}
 
+		for _, file := range topLevelDir.Files() {
+			b.logger.Debug("Gray{Debug➤ Found asset file} White{%s} with permission White{%s}",
+				file.Name().String(), file.PermissionSet().String())
+		}
 		files.WalkDirectoryTree(topLevelDir, func(d files.Directory) {
 			b.logger.Debug("Gray{Debug➤ Found asset directory} White{%s} with permission White{%s}",
 				d.Name().String(), d.PermissionSet().String())

--- a/internal/golada/builder/builder_test_suite.go
+++ b/internal/golada/builder/builder_test_suite.go
@@ -28,5 +28,5 @@ type DevNullWriter struct {
 
 // Write writes literally nothing
 func (DevNullWriter) Write(p []byte) (n int, err error) {
-	return 0, nil
+	return len(p), nil
 }

--- a/internal/golada/cmd/cleanup.go
+++ b/internal/golada/cmd/cleanup.go
@@ -45,37 +45,42 @@ var cleanupCommand = &cobra.Command{
 			l = logger.NewDefaultLogger(os.Stdout, logger.Info)
 		}
 
-		e := filepath.Walk(".", func(path string, info os.FileInfo, err error) error {
-			if GoFileSelector.Match([]byte(info.Name())) {
-				file, err := os.Open(path)
-				if err != nil {
-					return err
-				}
-
-				fileReader := bufio.NewReader(file)
-				line, _, err := fileReader.ReadLine()
-				if err != nil {
-					_ = file.Close()
-					return err
-				}
-
-				if err := file.Close(); err != nil {
-					return err
-				}
-				if strings.EqualFold(string(line), builder.IdentifierString) {
-					if err := os.Remove(path); err != nil {
-						return err
-					}
-					l.Debug("Gray{Debug➤ Removed pina-golada file} LimeGreen{%s}", file.Name())
-				}
-			}
-			return nil
-		})
-		if e != nil {
-			log.Fatalf("could not iterrate over the files in this directory %s", e.Error())
-		}
-		l.Info("Aqua{%s}➤ Cleaned project from pina-golada file", "Pina-Golada")
+		Cleanup(".", l)
 	},
+}
+
+// Cleanup cleans the given path of all pina-golada generated files
+func Cleanup(path string, l logger.Logger) {
+	e := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
+		if GoFileSelector.Match([]byte(info.Name())) {
+			file, err := os.Open(path)
+			if err != nil {
+				return err
+			}
+
+			fileReader := bufio.NewReader(file)
+			line, _, err := fileReader.ReadLine()
+			if err != nil {
+				_ = file.Close()
+				return err
+			}
+
+			if err := file.Close(); err != nil {
+				return err
+			}
+			if strings.EqualFold(string(line), builder.IdentifierString) {
+				if err := os.Remove(path); err != nil {
+					return err
+				}
+				l.Debug("Gray{Debug➤ Removed pina-golada file} LimeGreen{%s}", file.Name())
+			}
+		}
+		return nil
+	})
+	if e != nil {
+		log.Fatalf("could not iterrate over the files in this directory %s", e.Error())
+	}
+	l.Info("Aqua{%s}➤ Cleaned project from pina-golada file", "Pina-Golada")
 }
 
 func init() {

--- a/pkg/annotation/csv_parser.go
+++ b/pkg/annotation/csv_parser.go
@@ -51,7 +51,7 @@ func (c *CsvParser) Parse(comment string, annotation Annotation) (e error) {
 	keyValuePair := strings.Split(s, ";")
 	for _, paired := range keyValuePair {
 		keyToValue := strings.Split(paired, ",")
-		if len(keyValuePair) >= 2 {
+		if len(keyToValue) >= 2 {
 			foundAnnotation[keyToValue[0]] = keyToValue[1]
 		}
 	}

--- a/pkg/annotation/label_parser.go
+++ b/pkg/annotation/label_parser.go
@@ -51,7 +51,7 @@ func (c *LabelParser) Parse(comment string, annotation Annotation) (e error) {
 	keyValuePair := strings.Split(s, " ")
 	for _, paired := range keyValuePair {
 		keyToValue := strings.Split(paired, ",")
-		if len(keyValuePair) >= 2 {
+		if len(keyToValue) >= 2 {
 			foundAnnotation[keyToValue[0]] = keyToValue[1]
 		}
 	}

--- a/pkg/annotation/property_parser.go
+++ b/pkg/annotation/property_parser.go
@@ -51,7 +51,7 @@ func (p *PropertyParser) Parse(comment string, annotation Annotation) (e error) 
 	keyValuePair := strings.Split(s, "&")
 	for _, paired := range keyValuePair {
 		keyToValue := strings.Split(paired, "=")
-		if len(keyValuePair) >= 2 {
+		if len(keyToValue) >= 2 {
 			foundAnnotation[keyToValue[0]] = keyToValue[1]
 		}
 	}

--- a/pkg/files/directory.go
+++ b/pkg/files/directory.go
@@ -306,6 +306,7 @@ func copyDirectory(original Directory, new Directory) error {
 // NewRootDirectory returns a new root directory
 func NewRootDirectory() Directory {
 	return &memoryDirectory{
-		name: paths.RootPath(),
+		name:     paths.RootPath(),
+		PermBits: 0777,
 	}
 }

--- a/pkg/files/files_test.go
+++ b/pkg/files/files_test.go
@@ -24,6 +24,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -172,6 +173,11 @@ var _ = Describe("should handle files properly", func() {
 	})
 
 	_ = It("should overwrite permission sets on files", func() {
+		if IsOS("windows") {
+			Skip("Skipped on windows")
+			return
+		}
+
 		pathToTestDir := "../../assets/tests/issue-51/file"
 		pathToTestFile := filepath.Join(pathToTestDir, "permission.txt")
 
@@ -188,6 +194,11 @@ var _ = Describe("should handle files properly", func() {
 	})
 
 	_ = It("should overwrite permission sets on directories", func() {
+		if IsOS("windows") {
+			Skip("Skipped on windows")
+			return
+		}
+
 		pathToTestDir := "../../assets/tests/issue-51/directory"
 		pathToTestTarget := filepath.Join(pathToTestDir, "permission")
 
@@ -208,4 +219,8 @@ func GetFilePermission(path string) os.FileMode {
 	info, e := os.Stat(path)
 	Expect(e).To(Not(HaveOccurred()))
 	return info.Mode()
+}
+
+func IsOS(os string) bool {
+	return runtime.GOOS == os
 }

--- a/pkg/files/files_util.go
+++ b/pkg/files/files_util.go
@@ -141,7 +141,10 @@ func writeFileToDisk(file File, directoryPath string, overwrite bool) (e error) 
 		}
 
 		if fileOnDisk, e = os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, file.PermissionSet()); e == nil { // Creating the path given that it doesn't exist
-			if err := fileOnDisk.Close(); err != nil {
+			if err := fileOnDisk.Close(); err != nil { // Close stream again
+				return err
+			}
+			if err := os.Chmod(path, file.PermissionSet()); err != nil { // Chmod the file
 				return err
 			}
 		} else {
@@ -204,7 +207,7 @@ func writeDirectoryToDisk(directory Directory, directoryPath string, overwrite b
 		return fmt.Errorf("provided path pointed to file %s", directoryPath)
 	}
 
-	if overwrite && info.Mode() != permissionSet { // Overwrite permissions if overwrite is enabled
+	if overwrite && info.Mode() != permissionSet && directory.Parent() != nil { // Overwrite permissions if overwrite is enabled and folder is actual folder (not root)
 		if err := os.Chmod(directoryPath, permissionSet); err != nil {
 			return err
 		}

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -26,6 +26,7 @@ GO111MODULE=on ginkgo -r \
   --randomizeAllSpecs \
   --randomizeSuites \
   --failOnPending \
+  --slowSpecThreshold=30 \
   --nodes=4 \
   --compilers=2 \
   --race \

--- a/test/integration/.test/assets/file.txt
+++ b/test/integration/.test/assets/file.txt
@@ -1,0 +1,1 @@
+All Your Base Are Belong to Us

--- a/test/integration/.test/assets/folder/content.md
+++ b/test/integration/.test/assets/folder/content.md
@@ -1,0 +1,1 @@
+Hello there. General Kenobi.

--- a/test/integration/.test/integration_test.go
+++ b/test/integration/.test/integration_test.go
@@ -1,0 +1,114 @@
+/*
+ * Copyright © 2019 The Homeport Team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package test
+
+import (
+	"bytes"
+	"github.com/homeport/pina-golada/pkg/files"
+	"github.com/homeport/pina-golada/pkg/files/paths"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestIntegration(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "pgl .test sample")
+}
+
+var _ = AfterSuite(func() {
+	Expect(os.RemoveAll("assets/test")).To(Not(HaveOccurred()))
+})
+
+var _ = Describe("Should have generated correctly", func() {
+	_ = It("should compile file correctly", func() {
+		dir, e := Provider.GetFileAsset()
+		Expect(e).To(Not(HaveOccurred()))
+		Expect(dir).To(Not(BeNil()))
+
+		file := dir.File(paths.Of("file.txt"))
+		Expect(file).To(Not(BeNil()))
+		if NotWindows() {
+			Expect(file.PermissionSet().Perm()).To(BeEquivalentTo(0733))
+		}
+
+		buffer := &bytes.Buffer{}
+		Expect(file.CopyContent(buffer)).To(Not(HaveOccurred()))
+		Expect(buffer.String()).To(BeEquivalentTo("All Your Base Are Belong to Us"))
+	})
+
+	_ = It("should have compiled folder correctly", func() {
+		dir, e := Provider.GetFolderAsset()
+		Expect(e).To(Not(HaveOccurred()))
+		Expect(dir).To(Not(BeNil()))
+
+		Expect(dir.Name().String()).To(BeEquivalentTo("folder"))
+
+		content := dir.File(paths.Of("content.md"))
+		Expect(dir).To(Not(BeNil()))
+
+		buffer := &bytes.Buffer{}
+		Expect(content.CopyContent(buffer)).To(Not(HaveOccurred()))
+		Expect(buffer.String()).To(BeEquivalentTo("Hello there. General Kenobi."))
+	})
+
+	_ = It("should write files correctly", func() {
+		dir, e := Provider.GetFileAsset()
+		Expect(e).To(Not(HaveOccurred()))
+		Expect(dir).To(Not(BeNil()))
+
+		Expect(files.WriteToDisk(dir, "assets/test/", true)).To(Not(HaveOccurred()))
+
+		file, e := ioutil.ReadFile("assets/test/file.txt")
+		Expect(e).To(Not(HaveOccurred()))
+		Expect(string(file)).To(BeEquivalentTo("All Your Base Are Belong to Us"))
+
+		if !IsOS("windows") {
+			Expect(GetFilePermission("assets/test/file.txt").Perm()).To(BeEquivalentTo(0733))
+		}
+	})
+
+	_ = It("should write directories correctly", func() {
+		dir, e := Provider.GetFolderAsset()
+		Expect(e).To(Not(HaveOccurred()))
+		Expect(dir).To(Not(BeNil()))
+
+		Expect(files.WriteToDisk(dir, "assets/test/", true)).To(Not(HaveOccurred()))
+
+		file, e := ioutil.ReadFile("assets/test/folder/content.md")
+		Expect(e).To(Not(HaveOccurred()))
+		Expect(string(file)).To(BeEquivalentTo("Hello there. General Kenobi."))
+
+		if !IsOS("windows") {
+			Expect(GetFilePermission("assets/test/folder/content.md").Perm()).To(BeEquivalentTo(0722))
+			Expect(GetFilePermission("assets/test/folder").Perm()).To(BeEquivalentTo(0723))
+		}
+	})
+})
+
+// NotWindows returns if the system is not windows
+func NotWindows() bool {
+	return !IsOS("windows")
+}

--- a/test/integration/.test/integration_test_suite.go
+++ b/test/integration/.test/integration_test_suite.go
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2019 The Homeport Team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package test
+
+import (
+	"bytes"
+	"github.com/homeport/pina-golada/pkg/files"
+	. "github.com/onsi/gomega"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+var Provider Assets
+
+// Assets is the test injector variable
+// @pgl(injector=Provider)
+type Assets interface {
+	// @pgl(asset=assets/file.txt&compressor=tar)
+	GetFileAsset() (dir files.Directory, e error)
+
+	// @pgl(asset=assets/folder&compressor=tar)
+	GetFolderAsset() (dir files.Directory, e error)
+}
+
+// IsOS returns if the current os equals the string
+func IsOS(os string) bool {
+	return runtime.GOOS == os
+}
+
+// DevNull defines a logger that just ignores all output
+type DevNull struct{}
+
+// Write writes the bytes in the DevNull buffer
+func (*DevNull) Write(p []byte) (n int, err error) {
+	return 0, nil
+}
+
+// GetFilePermission returns the permission of the file
+func GetFilePermission(path string) os.FileMode {
+	info, e := os.Stat(filepath.FromSlash(path))
+	Expect(e).To(Not(HaveOccurred()))
+	return info.Mode()
+}
+
+type BufferedWriter struct {
+	Buffer *bytes.Buffer
+}
+
+func (b BufferedWriter) Write(p []byte) (n int, err error) {
+	b.Buffer.Write(p)
+	return len(p), nil
+}

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -1,0 +1,92 @@
+/*
+ * Copyright © 2019 The Homeport Team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package integration
+
+import (
+	"bytes"
+	"github.com/homeport/pina-golada/internal/golada/builder"
+	"github.com/homeport/pina-golada/internal/golada/cmd"
+	"github.com/homeport/pina-golada/internal/golada/logger"
+	"github.com/homeport/pina-golada/pkg/annotation"
+	test "github.com/homeport/pina-golada/test/integration/.test"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"os"
+	"os/exec"
+	"testing"
+)
+
+func TestCompileIntegrationTest(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "pgl integration compile")
+}
+
+var _ = SynchronizedBeforeSuite(func() []byte {
+	Expect(os.Chdir(".test")).To(Not(HaveOccurred())) // Change into the hidden test directory to target it
+
+	Expect(os.Chmod("assets/file.txt" , 0733)).To(Not(HaveOccurred()))
+	Expect(os.Chmod("assets/folder" , 0723)).To(Not(HaveOccurred()))
+	Expect(os.Chmod("assets/folder/content.md" , 0722)).To(Not(HaveOccurred()))
+
+	cmd.Generate(".", annotation.NewPropertyParser(), newLogger())
+
+	Expect(os.Chdir("..")).To(Not(HaveOccurred())) // Return to the original directory
+	return make([]byte, 0)
+}, func(ignored []byte) {})
+
+var _ = SynchronizedAfterSuite(func() {}, func() {
+	cmd.Cleanup(".test/", newLogger())
+})
+
+var _ = Describe("should compile provided unit test", func() {
+
+	var (
+		buffer *bytes.Buffer
+		writer test.BufferedWriter
+	)
+
+	_ = BeforeEach(func() {
+		buffer = &bytes.Buffer{}
+		writer = test.BufferedWriter{Buffer: buffer}
+	})
+
+	_ = It("should run the unit-tests in the compiled integration test", func() {
+		Expect(os.Chdir(".test")).To(Not(HaveOccurred())) // Change into the hidden test directory to target it
+
+		command := exec.Command("go", "test", "./...", "--", "count=1")
+		command.Stdout = writer
+		command.Stderr = os.Stderr
+		if err := command.Run(); err != nil {
+			_, err := os.Stdout.Write(buffer.Bytes())
+			Expect(err).To(Not(HaveOccurred()))
+			Fail("failed integration tests, check above")
+			return
+		}
+
+		Expect(os.Chdir("..")).To(Not(HaveOccurred())) // Return to the original directory
+	})
+})
+
+func newLogger() *logger.DefaultLogger {
+	return logger.NewDefaultLogger(&builder.DevNullWriter{}, logger.Info)
+}


### PR DESCRIPTION
As pina-golada did struggle a lot in the latest releases, this commit
adds an integration test to the project which compiles a test project
and tests for correct compilation and write to disk functionality.

As pina-golada generation cannot be dynamically loaded/unloaded, the implemented integration tests basically consist of three states. 

1. The first tests that are run are the pre-tests which generate the asset implementation as well as set up the file permission on the file system. 
2. The second tests are run as an integration which tests for the actual pina-golada code working.
3. The third tests are run as the post-tests which delete local test files and cleans up the pina-golada source.
