### PR TITLE
Update travis release condition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,5 +22,5 @@ deploy:
   file_glob: true
   file: binaries/*
   on:
-    condition: $TRAVIS_GO_VERSION =~ ^1\.11
+    condition: $TRAVIS_GO_VERSION =~ ^1\.12
     tags: true


### PR DESCRIPTION
Travis should build a release binary when the go version is 1.12. As the
previous PR did remove the 1.11 build configurations, this commit now
fixes build generation.